### PR TITLE
fix: ordering

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,13 +24,13 @@ const apnProviderProd = new apn.Provider(optionsProd);
 const configs = [
   {
     topic: process.env.TOPIC,
-    apnProvider: apnProviderDev,
-    app: "iOS",
+    apnProvider: apnProviderProd,
+    app: "iOS.production",
   },
   {
     topic: process.env.TOPIC,
-    apnProvider: apnProviderProd,
-    app: "iOS.production",
+    apnProvider: apnProviderDev,
+    app: "iOS",
   },
   // TODO: support watch app
 ];
@@ -95,7 +95,7 @@ exports.sendNotification = async function sendNotification({
     if (payload !== undefined) {
       notification.payload = payload;
     }
-    console.log("Notification to send", notification);
+    console.log("Notification to send for app " + app, notification);
 
     const deviceTokens = await getDeviceTokens(app);
     if (!deviceTokens.length) {

--- a/tests/send-test-notification.js
+++ b/tests/send-test-notification.js
@@ -3,6 +3,7 @@ const opengluckApn = require("..");
 (async () => {
   await opengluckApn.sendNotification({
     alert: { title: "Test Notification", body: "This is a test notification" },
+    contentAvailable: true,
     sound: "default",
     category: "LOW",
   });


### PR DESCRIPTION
- Sends notifications on app tokens first
- Improve readability in logs
- Improve `tests/send-test-notification.js` to have content so as to be able to debug handling notifications in apps